### PR TITLE
chore(ci: increase workflow timeout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
 jobs:
     build:
         runs-on: ${{ matrix.platform }}
-        timeout-minutes: 3
+        timeout-minutes: 7
         strategy:
             fail-fast: false
             matrix:


### PR DESCRIPTION
Increase the timeout of ``build.yml`` from 3 minutes to 7.